### PR TITLE
Inline loaders concept: replace 'overwrite' with 'override'

### DIFF
--- a/src/content/concepts/loaders.md
+++ b/src/content/concepts/loaders.md
@@ -81,7 +81,7 @@ It's possible to specify loaders in an `import` statement, or any [equivalent "i
 import Styles from 'style-loader!css-loader?modules!./styles.css';
 ```
 
-It's possible to overwrite any loaders in the configuration by prefixing the entire rule with `!`.
+It's possible to override any loaders in the configuration by prefixing the entire rule with `!`.
 
 Options can be passed with a query parameter, e.g. `?key=value&foo=bar`, or a JSON object, e.g. `?{"key":"value","foo":"bar"}`.
 


### PR DESCRIPTION
'overwrite' implies that the webpack config will be overwritten
with the inline loader config. 'override' is more accurate.

_describe your changes..._

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
